### PR TITLE
Dual pane layout

### DIFF
--- a/_includes/player.html
+++ b/_includes/player.html
@@ -1,0 +1,46 @@
+<div class="player">
+  <header class="player-header">
+{% assign title = 'Escúchalo' %}
+{% if page.path == 'index.html' %}{% assign title = 'Programa más reciente' %}{% endif %}
+    <h2>{{ title }}</h2>
+
+    <span class="player-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+    <h3>
+      <a class="player-title" href="{{ post.url | prepend: site.baseurl }}"
+      >{{ post.title }}</a>
+    </h3>
+  </header>
+
+  <section class="player-details">
+
+    <div class="player-logo"></div>
+
+{% if page.layout != 'post' %}
+    <h3>Notas al programa</h3>
+    <div class="player-notes">
+      {{ post.content }}
+    </div>
+{% else %}
+    <h3>Extracto</h3>
+    <div class="player-notes">
+      {{ post.excerpt }}
+
+      <p>Puedes encontrar el resto de las notas y enlaces a la derecha.</p>
+    </div>
+{% endif %}
+  </section>
+
+{% if post.track-mp3 %}
+  <section class="player-ui">
+{% for track in post.track-mp3 %}
+    <audio preload="metadata" controls>
+      <source
+        type="audio/mpeg"
+        src="{{ track }}"
+      />
+    </audio>
+{% endfor %}
+
+  </section>
+{% endif %}
+</div>

--- a/_includes/player.html
+++ b/_includes/player.html
@@ -1,14 +1,15 @@
+{% if page.path == 'index.html' %}
+  {% assign pane_title = 'Programa más reciente' %}
+  {% assign notes_title = 'Notas al programa' %}
+{% endif %}
 <div class="player">
   <header class="player-header">
-{% assign title = 'Escúchalo' %}
-{% if page.path == 'index.html' %}{% assign title = 'Programa más reciente' %}{% endif %}
     <div class="wrapper">
-      <h2>{{ title }}</h2>
+      <h2>{{ pane_title | default: 'Escúchalo' }}</h2>
 
       <span class="player-date">{{ post.date | date: "%b %-d, %Y" }}</span>
       <h3>
-        <a class="player-title" href="{{ post.url | prepend: site.baseurl }}"
-        >{{ post.title }}</a>
+        <a class="player-title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
       </h3>
     </div>
   </header>
@@ -18,19 +19,18 @@
 
       <div class="player-logo"></div>
 
-{% if page.layout != 'post' %}
-      <h3>Notas al programa</h3>
-      <div class="player-notes">
-        {{ post.content }}
-      </div>
-{% else %}
-      <h3>Extracto</h3>
-      <div class="player-notes">
-        {{ post.excerpt }}
+      <h3 class="player-notes-title">
+        {{ notes_title | default: 'Extracto' }}
+      </h3>
 
-        <p>Puedes encontrar el resto de las notas y enlaces a la derecha.</p>
-      </div>
+      <div class="player-notes">
+        <p class="player-notes-excerpt">
+          {{ post.excerpt | remove: '<p>' | remove: '</p>' }}
+        </p>
+{% if page.layout != 'post' %}
+        {{ post.content | remove: post.excerpt }}
 {% endif %}
+      </div>
     </div>
   </section>
 

--- a/_includes/player.html
+++ b/_includes/player.html
@@ -2,32 +2,36 @@
   <header class="player-header">
 {% assign title = 'Escúchalo' %}
 {% if page.path == 'index.html' %}{% assign title = 'Programa más reciente' %}{% endif %}
-    <h2>{{ title }}</h2>
+    <div class="wrapper">
+      <h2>{{ title }}</h2>
 
-    <span class="player-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-    <h3>
-      <a class="player-title" href="{{ post.url | prepend: site.baseurl }}"
-      >{{ post.title }}</a>
-    </h3>
+      <span class="player-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+      <h3>
+        <a class="player-title" href="{{ post.url | prepend: site.baseurl }}"
+        >{{ post.title }}</a>
+      </h3>
+    </div>
   </header>
 
   <section class="player-details">
+    <div class="wrapper">
 
-    <div class="player-logo"></div>
+      <div class="player-logo"></div>
 
 {% if page.layout != 'post' %}
-    <h3>Notas al programa</h3>
-    <div class="player-notes">
-      {{ post.content }}
-    </div>
+      <h3>Notas al programa</h3>
+      <div class="player-notes">
+        {{ post.content }}
+      </div>
 {% else %}
-    <h3>Extracto</h3>
-    <div class="player-notes">
-      {{ post.excerpt }}
+      <h3>Extracto</h3>
+      <div class="player-notes">
+        {{ post.excerpt }}
 
-      <p>Puedes encontrar el resto de las notas y enlaces a la derecha.</p>
-    </div>
+        <p>Puedes encontrar el resto de las notas y enlaces a la derecha.</p>
+      </div>
 {% endif %}
+    </div>
   </section>
 
 {% if post.track-mp3 %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,27 @@
     {% include header.html %}
 
     <div class="page-content">
-      <div class="wrapper">
-        {{ content }}
-      </div>
-    </div>
 
-    {% include footer.html %}
+      {% if page.layout == 'post' %}
+        {% if page.categories contains 'podcast' %}
+          {% assign post = page %}
+          {% include player.html %}
+        {% endif %}
+      {% elsif page.path == 'index.html' %}
+        {% assign post = site.categories.podcast | where_exp: "post", "post.track-mp3" | first %}
+        {% include player.html %}
+      {% endif %}
+
+
+      <div class="content">
+        <div class="wrapper">
+          {{ content }}
+        </div>
+
+        {% include footer.html %}
+      </div>
+
+    </div>
 
   </body>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,6 +9,18 @@ layout: default
   </header>
 
   <div class="post-content" itemprop="articleBody">
+{% if page.listen-msg %}
+    <p>
+      {{ page.listen-msg | markdownify }}
+    </p>
+{% elsif page.spreaker or page.itunes %}
+    <p>
+      Escuchar
+      {% if page.spreaker %}en <a href="{{ page.spreaker }}">Spreaker</a>{% endif %}
+      {% if page.spreaker and page.itunes %}o{% endif %}
+      {% if page.itunes %}en <a href="{{ page.itunes }}">iTunes</a>{% endif %}.
+    </p>
+{% endif %}
     {{ content }}
   </div>
 

--- a/_posts/2016-03-13-NL7_bitcoin.markdown
+++ b/_posts/2016-03-13-NL7_bitcoin.markdown
@@ -5,6 +5,7 @@ date:   2016-03-13 20:23:00 +0100
 categories: podcast
 spreaker: http://www.spreaker.com/user/nacionlumpen/nl7-bitcoin-contado-a-los-informa-ticos
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/7995691/nl7_bitcoin_2.mp3
 ---
 
 Episodio 7 del podcast en el damos una introducción a los aspectos técnicos de

--- a/_posts/2016-03-13-NL7_bitcoin.markdown
+++ b/_posts/2016-03-13-NL7_bitcoin.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL7: Bitcoin contado a los informáticos"
 date:   2016-03-13 20:23:00 +0100
 categories: podcast
+spreaker: http://www.spreaker.com/user/nacionlumpen/nl7-bitcoin-contado-a-los-informa-ticos
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](http://www.spreaker.com/user/nacionlumpen/nl7-bitcoin-contado-a-los-informa-ticos) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Episodio 7 del podcast en el damos una introducción a los aspectos técnicos de
 Bitcoin. Por una vez en la vida nos acordamos de recordar que tenemos cuenta

--- a/_posts/2016-04-13-NL8_mobile.markdown
+++ b/_posts/2016-04-13-NL8_mobile.markdown
@@ -5,6 +5,7 @@ date:   2016-04-13 21:00:00 +0100
 categories: podcast
 spreaker: http://www.spreaker.com/user/nacionlumpen/nl8-asomandonos-al-desarrollo-movil
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/8252983/nl8.mp3
 ---
 
 Hoy nos asomamos al desarrolo móvil de la mano de estos monstruos:

--- a/_posts/2016-04-13-NL8_mobile.markdown
+++ b/_posts/2016-04-13-NL8_mobile.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL8: asomándonos al desarrollo móvil"
 date:   2016-04-13 21:00:00 +0100
 categories: podcast
+spreaker: http://www.spreaker.com/user/nacionlumpen/nl8-asomandonos-al-desarrollo-movil
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](http://www.spreaker.com/user/nacionlumpen/nl8-asomandonos-al-desarrollo-movil) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Hoy nos asomamos al desarrolo móvil de la mano de estos monstruos:
 

--- a/_posts/2016-04-22-NL9_fango.markdown
+++ b/_posts/2016-04-22-NL9_fango.markdown
@@ -7,6 +7,9 @@ x-spreaker:
  - https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango
  - https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango-parte-2
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3:
+ - https://api.spreaker.com/download/episode/8576185/nl9_saliendo_del_fango_parte1.mp3
+ - https://api.spreaker.com/download/episode/8576357/nl9_saliendo_del_fango_parte_2.mp3
 listen-msg: >
   Escuchar en
   Spreaker ([parte 1](https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango), [parte 2](https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango-parte-2)) o en

--- a/_posts/2016-04-22-NL9_fango.markdown
+++ b/_posts/2016-04-22-NL9_fango.markdown
@@ -17,7 +17,9 @@ listen-msg: >
 ---
 
 Charlamos sobre el artículo de culto *Out of the Tar Pit*, de Peter Marks y
-Ben Moseley. Contamos con los siguientes contertulios:
+Ben Moseley.
+
+Contamos con los siguientes contertulios:
 
  - Daniel Martín, [@dmartincy](https://twitter.com/dmartincy)
  - Álvaro Castellanos, [@AlvaroCaste](https://twitter.com/AlvaroCaste)

--- a/_posts/2016-04-22-NL9_fango.markdown
+++ b/_posts/2016-04-22-NL9_fango.markdown
@@ -3,11 +3,15 @@ layout: post
 title:  "NL9: saliendo del fango"
 date:   2016-04-22 21:00:00 +0100
 categories: podcast
+x-spreaker:
+ - https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango
+ - https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango-parte-2
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+listen-msg: >
+  Escuchar en
+  Spreaker ([parte 1](https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango), [parte 2](https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango-parte-2)) o en
+  [iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2).
 ---
-
-Escuchar en
-([parte1](https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango), [parte2](https://www.spreaker.com/user/nacionlumpen/nl9-saliendo-del-fango-parte-2)) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Charlamos sobre el artículo de culto *Out of the Tar Pit*, de Peter Marks y
 Ben Moseley. Contamos con los siguientes contertulios:

--- a/_posts/2016-10-04-NL10_progfun.markdown
+++ b/_posts/2016-10-04-NL10_progfun.markdown
@@ -5,6 +5,7 @@ date:   2016-10-03 00:00:00 +0100
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl10-programacion-funcional
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/9557347/nl10_progfun.mp3
 ---
 
 Aprovechando el marco incomparable que nos ofrecía la [Lambda World][lambda]

--- a/_posts/2016-10-04-NL10_progfun.markdown
+++ b/_posts/2016-10-04-NL10_progfun.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL10: programación funcional"
 date:   2016-10-03 00:00:00 +0100
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl10-programacion-funcional
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl10-programacion-funcional) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Aprovechando el marco incomparable que nos ofrecía la [Lambda World][lambda]
 nos propusimos hablar sobre programación funcional con unos invitados

--- a/_posts/2016-10-23-NL11_edades.markdown
+++ b/_posts/2016-10-23-NL11_edades.markdown
@@ -5,6 +5,7 @@ date:   2016-10-23 00:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl11-las-edades-del-programador
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/9705773/nl11_edades_del_programador_final.mp3
 ---
 
 En esta ocasión buscamos dar una visión del mundo de la programación desde la

--- a/_posts/2016-10-23-NL11_edades.markdown
+++ b/_posts/2016-10-23-NL11_edades.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL11: las edades del programador"
 date:   2016-10-23 00:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl11-las-edades-del-programador
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl11-las-edades-del-programador) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 En esta ocasión buscamos dar una visión del mundo de la programación desde la
 perspectiva de un programador de la franja de 20 años hasta la de uno de la

--- a/_posts/2016-11-30-NL12_practice.markdown
+++ b/_posts/2016-11-30-NL12_practice.markdown
@@ -5,6 +5,7 @@ date:   2016-11-30 12:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl12-practica-deliberada
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/10008448/nl12_practica_deliberada.mp3
 ---
 
 Alcanzar maestría no es simplemente practicar de cualquier forma durante 10k

--- a/_posts/2016-11-30-NL12_practice.markdown
+++ b/_posts/2016-11-30-NL12_practice.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL12: práctica deliberada"
 date:   2016-11-30 12:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl12-practica-deliberada
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl12-practica-deliberada) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Alcanzar maestría no es simplemente practicar de cualquier forma durante 10k
 horas o cierto número de años. Nuestro objetivo en este capítulo es ver este

--- a/_posts/2017-01-20-NL13_paradigmas.markdown
+++ b/_posts/2017-01-20-NL13_paradigmas.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL13: paradigmas"
 date:   2017-01-20 12:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl13-paradigmas
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl13-paradigmas) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 En este capítulo hablamos sobre los paradigmas de la programación más comunes.
 A pesar de que siempre estemos hablando de programación orientada a objetos y

--- a/_posts/2017-01-20-NL13_paradigmas.markdown
+++ b/_posts/2017-01-20-NL13_paradigmas.markdown
@@ -5,6 +5,7 @@ date:   2017-01-20 12:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl13-paradigmas
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/10349115/nl13_paradigmas.mp3
 ---
 
 En este capítulo hablamos sobre los paradigmas de la programación más comunes.

--- a/_posts/2017-03-26-NL14_retro.markdown
+++ b/_posts/2017-03-26-NL14_retro.markdown
@@ -5,6 +5,7 @@ date:   2017-03-26 10:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl14-retro
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/11482645/nl14_retro.mp3
 ---
 
 No sabemos cómo pero hemos engañado a [Carlos Abril][carlos], mítico

--- a/_posts/2017-03-26-NL14_retro.markdown
+++ b/_posts/2017-03-26-NL14_retro.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL14: retro"
 date:   2017-03-26 10:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl14-retro
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en 
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl14-retro) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 No sabemos cómo pero hemos engañado a [Carlos Abril][carlos], mítico
 desarrollador de la época de oro de los 8 bits en España y posteriormente

--- a/_posts/2018-02-18-NL15_peopleware.markdown
+++ b/_posts/2018-02-18-NL15_peopleware.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL15: Peopleware"
 date:   2018-02-18 10:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl15-peopleware
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl15-peopleware) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Como prometimos durante el [Advent of Code][AoC] seguimos vivos y hemos vuelto
 con un nuevo capítulo del podcast. En esta ocasión volvemos a pendular al lado

--- a/_posts/2018-02-18-NL15_peopleware.markdown
+++ b/_posts/2018-02-18-NL15_peopleware.markdown
@@ -5,6 +5,7 @@ date:   2018-02-18 10:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl15-peopleware
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/14081379/nl15_peopleware.mp3
 ---
 
 Como prometimos durante el [Advent of Code][AoC] seguimos vivos y hemos vuelto

--- a/_posts/2018-04-25-NL16_javascript.markdown
+++ b/_posts/2018-04-25-NL16_javascript.markdown
@@ -5,6 +5,7 @@ date:   2018-04-25 10:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/8241695/nl16-javascript
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/14619358/nl16_javascript.mp3
 ---
 
 *I amar prestar aen (El Mundo ha cambiado)*

--- a/_posts/2018-04-25-NL16_javascript.markdown
+++ b/_posts/2018-04-25-NL16_javascript.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL16: Javascript moderno"
 date:   2018-04-25 10:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/8241695/nl16-javascript
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/8241695/nl16-javascript) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 *I amar prestar aen (El Mundo ha cambiado)*
 

--- a/_posts/2018-04-25-NL16_javascript.markdown
+++ b/_posts/2018-04-25-NL16_javascript.markdown
@@ -8,15 +8,15 @@ itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 track-mp3: https://api.spreaker.com/download/episode/14619358/nl16_javascript.mp3
 ---
 
-*I amar prestar aen (El Mundo ha cambiado)*
-
-*han mathon ne nen (Lo siento en el transpilador)*
-
-*han mathon ne chae (Lo siento en los frameworks)*
-
-*a han noston ned gwilith. (Lo huelo en la web)*
-
-
+*I amar prestar aen (El Mundo ha cambiado)*\\
+\\
+*han mathon ne nen (Lo siento en el transpilador)*\\
+\\
+*han mathon ne chae (Lo siento en los frameworks)*\\
+\\
+*a han noston ned gwilith. (Lo huelo en la web)*\\
+\\
+\\
 *Mucho se perdió entonces y pocos viven ahora para recordarlo.*
 
 ¿Cómo hemos podido llegar desde aquel momento en el que abrimos en el notepad

--- a/_posts/2018-06-24-NL17_drones.markdown
+++ b/_posts/2018-06-24-NL17_drones.markdown
@@ -5,6 +5,7 @@ date:   2018-06-24 00:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/8241695/nl17-drones
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/15119252/nl17_drones_24_06_2018_12_29.mp3
 ---
 
 Hoy vamos a hablar de drones. Pero no de cualquier forma porque contamos con

--- a/_posts/2018-06-24-NL17_drones.markdown
+++ b/_posts/2018-06-24-NL17_drones.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL17: drones"
 date:   2018-06-24 00:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/8241695/nl17-drones
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/8241695/nl17-drones) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 Hoy vamos a hablar de drones. Pero no de cualquier forma porque contamos con
 un auténtico experto autodidacta en este apasionante hobby, [Jose Ignacio

--- a/_posts/2018-07-28-NL18_tinfoil.markdown
+++ b/_posts/2018-07-28-NL18_tinfoil.markdown
@@ -5,6 +5,7 @@ date:   2018-07-28 00:00:00
 categories: podcast
 spreaker: https://www.spreaker.com/user/nacionlumpen/nl18-tinfoil
 itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
+track-mp3: https://api.spreaker.com/download/episode/15346691/nl18_tinfoil_exported.mp3
 ---
 
 En esta ocasión queremos poner sobre las ondas, una serie de cuestiones relacionadas

--- a/_posts/2018-07-28-NL18_tinfoil.markdown
+++ b/_posts/2018-07-28-NL18_tinfoil.markdown
@@ -3,11 +3,9 @@ layout: post
 title:  "NL18: Tinfoil"
 date:   2018-07-28 00:00:00
 categories: podcast
+spreaker: https://www.spreaker.com/user/nacionlumpen/nl18-tinfoil
+itunes: https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2
 ---
-
-Escuchar en
-[Spreaker](https://www.spreaker.com/user/nacionlumpen/nl18-tinfoil) o en
-[iTunes](https://itunes.apple.com/es/podcast/nacion-lumpen/id1023465004?l=en&mt=2)
 
 En esta ocasión queremos poner sobre las ondas, una serie de cuestiones relacionadas
 con cómo la tecnología está afectando a nuestra privacidad, libertad y cómo derechos

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -7,6 +7,10 @@ body {
 
   flex-direction: column;
 
+  @include media-query($on-palm * 2) {
+    height: unset;
+  }
+
   .site-header {
     flex-shrink: 0;
     flex-grow: 0;
@@ -196,6 +200,10 @@ body {
     display: flex;
     flex-direction: row;
     justify-content: center;
+
+    @include media-query($on-palm * 2) {
+      flex-direction: column;
+    }
 
     > * {
       width: 100%;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -69,6 +69,7 @@ body {
         position: absolute;
         top: 9px;
         right: $spacing-unit / 2;
+        z-index: 1;
         background-color: $background-color;
         border: 1px solid $grey-color-light;
         border-radius: 5px;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,10 +1,30 @@
 /**
+ * Site layout skeleton
+ */
+body {
+  height: 100vh;
+  display: flex;
+
+  flex-direction: column;
+
+  .site-header {
+    flex-shrink: 0;
+    flex-grow: 0;
+  }
+
+  .page-content {
+    flex-shrink: 1;
+    flex-grow: 1;
+    overflow: auto;
+  }
+}
+
+/**
  * Site header
  */
 .site-header {
     background-color: #333;
     border-top: 5px solid $grey-color-dark;
-    border-bottom: 1px solid $grey-color-light;
     min-height: 56px;
 
     // Positioning context for the mobile navigation icon
@@ -171,7 +191,16 @@
  * Page content
  */
 .page-content {
-    padding: $spacing-unit 0;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+
+    > * {
+      width: 100%;
+      padding: $spacing-unit 0;
+      overflow: auto;
+    }
 }
 
 .page-heading {

--- a/_sass/_player.scss
+++ b/_sass/_player.scss
@@ -22,7 +22,6 @@
   }
 
   .player-header, .player-details {
-    padding: 0 $spacing-unit;
   }
 
   .player-header {

--- a/_sass/_player.scss
+++ b/_sass/_player.scss
@@ -40,6 +40,14 @@
       margin: 0 auto $spacing-unit / 2;
 
       background: center / cover no-repeat $brand-color url('../img/background.png');
+
+      @include media-query($on-laptop) {
+        width: 15em;
+      }
+
+      @include media-query($on-palm) {
+        width: 10em;
+      }
     }
 
     .player-logo:after {
@@ -49,6 +57,16 @@
     }
 
     .player-notes {
+      &-title {
+        @include media-query($on-palm * 2) {
+          display: none;
+        }
+      }
+
+      :not(.player-notes-excerpt) {
+        @include media-query($on-palm * 2) {
+          display: none;
+        }
       }
     }
   }

--- a/_sass/_player.scss
+++ b/_sass/_player.scss
@@ -1,0 +1,68 @@
+.player {
+  position: relative; // serve of parent for absolutely positioned elements
+  padding-top: $spacing-unit;
+  padding-bottom: 0;
+
+  display: flex;
+  flex-direction: column;
+
+  color: $grey-color-light;
+
+  background: center/cover no-repeat;
+  background-image:
+    radial-gradient(
+      circle at center 75%,
+      $brand-color,
+      rgba(0, 0, 0, 0.8),
+    );
+
+
+  a {
+    color: $brand-secondary-color;
+  }
+
+  .player-header, .player-details {
+    padding: 0 $spacing-unit;
+  }
+
+  .player-header {
+    .player-title {
+      font-size: 25px;
+    }
+  }
+
+  .player-details {
+    flex-grow: 1;
+    overflow: auto;
+
+    .player-logo {
+      width: 20em;
+      max-width: 90%;
+      margin: 0 auto $spacing-unit / 2;
+
+      background: center / cover no-repeat $brand-color url('../img/background.png');
+    }
+
+    .player-logo:after {
+      content: "";
+      display: block;
+      padding-bottom: 100%; // dynamic square hack: padding is always calculated from width value
+    }
+
+    .player-notes {
+      }
+    }
+  }
+
+  .player-ui {
+    audio {
+      display: block;
+      width: 100%;
+
+      &:not(:first-child) {
+        border-top: 1px solid $brand-secondary-color;
+      }
+    }
+  }
+
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -50,5 +50,6 @@ $on-laptop:        800px;
 @import
         "base",
         "layout",
+        "player",
         "syntax-highlighting"
 ;

--- a/css/main.scss
+++ b/css/main.scss
@@ -16,7 +16,8 @@ $spacing-unit:     30px;
 
 $text-color:       #111;
 $background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
+$brand-color:      #de0000;
+$brand-secondary-color: #ffcc00;
 
 $grey-color:       #828282;
 $grey-color-light: lighten($grey-color, 40%);


### PR DESCRIPTION
## Summary

 - Leverages post [front matter](https://jekyllrb.com/docs/frontmatter/) for metadata
   - 1fef1dbdf8763c0e1ac5c86b8df48496ec7a19f0 No need to manually write "Escuchar en Spreaker o en iTunes" anymore
   - 554bfce2f0b406dc15ba51bd386f6df4fd233f38 MP3 direct link
 - Each post in the category `podcast` has a side pane with a player
 - Index page shows latest chapter published (queries for the latests post in the `podcast` category with a `track-mp3` URL)
 - Mobile view shows the player pane on top and simplified
 - 12cff8122ded82ed1ba9e5b97eb9b36c9b4f39a7 Site links now honor `$brand-color`
 - No JavaScript needed at all, :wink: 

## Caveat(s)

 - b69abc8766376afff80643c84781d24131ad4c92 Post's first paragraphs serves as a summary or excerpt
   - Trick: double backslash `\\` marks a manual line break, not breaking the paragraph 

All in all, posts should be easier to write.

Live demo here: https://roboe.github.io/nacionlumpen.github.io/

This is a gift, indeed, :smiley: 